### PR TITLE
exit semi-gracefully if the potential file doesn't exit

### DIFF
--- a/src/PyGalPot.cc
+++ b/src/PyGalPot.cc
@@ -9,8 +9,17 @@ using std::cin;
 extern "C" {
   GalaxyPotential* GalPot_new(char fname[]){
     ifstream file;
+    GalaxyPotential *Phi = NULL;
     file.open(fname);
-    GalaxyPotential *Phi = new GalaxyPotential(file);
+    if(file.is_open())
+      {
+	Phi = new GalaxyPotential(file);
+      }
+    else
+      {
+	cerr << "Potential file "<< fname << " doesn't exist. Exiting...\n";
+	exit(1);
+      }
     file.close();
     return Phi;
   }


### PR DESCRIPTION
Hi,

Currently, when using the python version of the code and the .pot file doesn't exist this 
message:
```Trying to construct Disks from a closed std::istream```
is shown, followed by the crash. 
The patch fixed that providing an explicit message 
```Potential file ***.pot doesn't exist. Exiting...```

Cheers,
     Sergey